### PR TITLE
Improve AddNotificationsByFluent method

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Se você deseja limpar todas as notificações, pode fazê-lo usando o método `
 
 #### Combinando com o FluentValidation
 
-Você também pode receber notificações do FluentValidation por meio do método `AddNotificationsByFluent`:
+Você também pode receber notificações do FluentValidation por meio do método `AddNotificationsByFluent`, passando um `ValidationResult` e o parâmetro `overwrite` como `true` caso queira limpar as notificações anteriores:
 
 ```csharp
 using Notie;
@@ -147,7 +147,7 @@ EntityValidator validator = new EntityValidator();
 ValidationResult result = validator.Validate(entity);
 
 var notifier = new Notifier();
-notifier.AddNotificationsByFluent(result);
+notifier.AddNotificationsByFluent(result, true);
 
 if (notifier.HasNotifications)
 {

--- a/src/Notie/Contracts/AbstractNotifier.cs
+++ b/src/Notie/Contracts/AbstractNotifier.cs
@@ -25,7 +25,7 @@ namespace Notie.Contracts
 
         public abstract void AddNotification (Notification notification);
         public abstract void AddNotifications (IEnumerable<Notification> notifications, bool overwrite = false);
-        public abstract void AddNotificationsByFluent (ValidationResult validationResult);
+        public abstract void AddNotificationsByFluent (ValidationResult validationResult, bool overwrite = false);
         public abstract void SetNotificationType (string type);
         public abstract void Clear ();
     }

--- a/src/Notie/Contracts/INotifier.cs
+++ b/src/Notie/Contracts/INotifier.cs
@@ -35,11 +35,12 @@ namespace Notie.Contracts
         ///     Inserts notifications from a FluentValidation validation.
         /// </summary>
         /// <param name="validationResult">Non-null result of a FluentValidation validator.</param>
+        /// /// <param name="overwrite">If true, it overwrites all notifications that already exist in the notifier.</param>
         /// <exception cref="Exceptions.ValidationResultIsNullException">
         ///     The exception is thrown when a null
         ///     validation is passed to the method that does not allow this operation.
         /// </exception>
-        void AddNotificationsByFluent (ValidationResult validationResult);
+        void AddNotificationsByFluent (ValidationResult validationResult, bool overwrite = false);
 
         /// <summary>
         ///     Defines the type of notification.

--- a/src/Notie/Notifier.cs
+++ b/src/Notie/Notifier.cs
@@ -43,14 +43,18 @@ namespace Notie
             }
         }
 
-        public override void AddNotificationsByFluent (ValidationResult validationResult)
+        public override void AddNotificationsByFluent (ValidationResult validationResult, bool overwrite = false)
         {
             if (validationResult is null)
             {
                 throw new ValidationResultIsNullException();
             }
 
-            _notifications.Clear();
+            if (overwrite)
+            {
+                _notifications.Clear();
+            }
+
             foreach (var error in validationResult.Errors)
             {
                 var notification = new Notification(


### PR DESCRIPTION
Includes an `overwrite` parameter to the AddNotificationsByFluent method so that the notifications in the context are not cleared up by default once this method is called